### PR TITLE
Remove Unnecessary Document about FF and Add Link to FF Repo

### DIFF
--- a/content/en/docs/concepts/function.md
+++ b/content/en/docs/concepts/function.md
@@ -17,3 +17,5 @@ Function aims to realize the lifecycle management from your source code to the f
 ## Reference
 
 For more information, see [Function Specifications](../../reference/component-reference/function-spec).
+
+For more information about OpenFunction Functions Framework, see [OpenFunction Functions Framework](https://github.com/OpenFunction/functions-framework).

--- a/content/en/docs/user-guide/use-function/run-functions-framework.md
+++ b/content/en/docs/user-guide/use-function/run-functions-framework.md
@@ -1,9 +1,0 @@
----
-title: "Run Functions Framework"
-linkTitle: "Run Functions Framework"
-weight: 4210
-description: >	
-    Learn how to run Functions Framework.
----
-
-TBD.

--- a/content/en/docs/user-guide/use-function/write-functions.md
+++ b/content/en/docs/user-guide/use-function/write-functions.md
@@ -1,7 +1,7 @@
 ---
 title: "Write Functions"
 linkTitle: "Write Functions"
-weight: 4220
+weight: 4210
 description: >	
     Learn how to write functions.
 ---


### PR DESCRIPTION
Signed-off-by: Felixnoo <felixliu@kubesphere.io>

#38 

@benjaminhuo @tpiperatgod 

Hi, I removed the document [Run Functions Framework](https://openfunction.dev/docs/user-guide/use-function/run-functions-framework/) and added a link to [the functions-framework repo](https://github.com/OpenFunction/functions-framework) in [this document](https://openfunction.dev/docs/concepts/function/).

Please take a look at this PR. If there is any other document that needs to be removed, please let me know. Thanks.