### PR TITLE
knative is the right path of hello-world-go instead of Knative

### DIFF
--- a/content/en/docs/getting-started/your-first-function/function-go.md
+++ b/content/en/docs/getting-started/your-first-function/function-go.md
@@ -48,7 +48,7 @@ kubectl create secret docker-registry push-secret \
          FUNC_CLEAR_SOURCE: "true"
        srcRepo:
          url: "https://github.com/OpenFunction/samples.git"
-         sourceSubPath: "functions/Knative/hello-world-go"
+         sourceSubPath: "functions/knative/hello-world-go"
          revision: "release-0.6"
      serving:
        template:


### PR DESCRIPTION
**Knative** is the wrong path and it continuously fails in build stage due to this issue.
![2022-05-20_09-04](https://user-images.githubusercontent.com/3123790/169428489-c3d5cc50-2b8f-46d8-8177-982b4d794dbf.png)

Signed-off-by: Alex Ji <jilichao@aliyun.com>